### PR TITLE
Add Blockheight Component to Chart Component

### DIFF
--- a/src/app/chart.tsx
+++ b/src/app/chart.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useRef } from 'react'
 import formatNumber from '@/utils/format-number'
 import useExchangeRate from '@/utils/hooks/useExchangeRate'
 import classNames from 'classnames'
+import Blockheight from '@/components/blockheight'
 
 const TABS = ['1h', '4h', '6h', '12h', '1D']
 
@@ -269,6 +270,7 @@ export default function Chart(props: {
 							</span>
 						</span>
 					</p>
+					<div><Blockheight /></div>
 				</div>
 				<div className="gap-2 grid grid-cols-5">{TABS.map(renderTab)}</div>
 			</div>

--- a/src/components/blockheight.tsx
+++ b/src/components/blockheight.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import useChainInfo from '@/utils/hooks/useChainInfo';
+
+const Blockheight: React.FC = () => {
+  const { data, isLoading } = useChainInfo();
+
+  return (
+    <div>
+      {isLoading ? (
+        <p>Loading chain info...</p>
+      ) : (
+        <div className="flex text-xs text-gray-300 ml-2">
+          <div className='w-full'> As Of Block: </div>
+          <div className='mr-2'>{data?.blocks}</div>
+          </div>
+      )}
+    </div>
+  );
+};
+
+export default Blockheight;

--- a/src/components/blockheight.tsx
+++ b/src/components/blockheight.tsx
@@ -9,10 +9,10 @@ const Blockheight: React.FC = () => {
       {isLoading ? (
         <p>Loading chain info...</p>
       ) : (
-        <div className="flex text-xs text-gray-300 ml-2">
-          <div className='w-full'> As Of Block: </div>
-          <div className='mr-2'>{data?.blocks}</div>
-          </div>
+        <div className="flex text-sm ml-2">
+          <div className='w-full text-gray-300'> Block Height: </div>
+          <div className='w-full mr-2 text-xs text-right text-white'>{data?.tip} / {data?.blocks}</div>
+        </div>
       )}
     </div>
   );

--- a/src/utils/hooks/useChainInfo.tsx
+++ b/src/utils/hooks/useChainInfo.tsx
@@ -14,8 +14,9 @@ export default function useChainInfo() {
 	)
 
 	const tip = (data?.blocks) || 0
+	
 	const historyTip = lockHistoryData ? parseInt(lockHistoryData?.slice(-1)?.[0]?.height, 10) : 0
-
+	data.tip = historyTip;
 	console.log({ tip, historyTip, blockDiff: tip - historyTip })
 
 	return { data, isLoading }


### PR DESCRIPTION
This pull request introduces the following changes:

    **New File**: Added a new file blockheight.tsx in the components/ folder. This file contains the Blockheight component, which displays the current block height.
    **Chart Component Update**: Integrated the Blockheight component into the Chart component, placing it under the "% locked" calculation section for enhanced visibility of the blockchain's current block height.

These changes aim to provide users with real-time information about the blockchain's block height directly within the Chart component, enhancing the overall user experience.