### PR TITLE
Fix X/extension links and replace Twitter icon with X

### DIFF
--- a/src/app/header.tsx
+++ b/src/app/header.tsx
@@ -3,9 +3,10 @@
 import React from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
-import { Chrome, Menu, Twitter, X } from 'lucide-react'
+import { Chrome, Menu, X } from 'lucide-react'
 import { GitHubLogoIcon } from '@radix-ui/react-icons'
 import { GitbookIcon } from '@/components/icons/gitbook-icon'
+import { XIcon } from '@/components/icons/x-icon'
 import { usePathname } from 'next/navigation'
 import { ConnectWalletButton } from '@/components/ui/connect-button'
 import { useWallet } from '@/components/layout'
@@ -207,13 +208,13 @@ export default function Header() {
 					<div className="flex items-center gap-2 md:gap-3.5">
 						<div className="hidden items-center gap-1.5 md:flex">
 							<a
-								href="https://twitter.com/yourswallet"
+								href="https://x.com/yoursxbt"
 								target="_blank"
 								rel="noreferrer"
 								className="inline-flex h-9 w-9 items-center justify-center text-white/80 transition hover:text-white"
-								aria-label="Follow Yours Wallet on Twitter"
+								aria-label="Follow Yours Wallet on X"
 							>
-								<Twitter className="h-4 w-4" />
+								<XIcon className="h-4 w-4" />
 							</a>
 							<a
 								href="https://yours-wallet.gitbook.io/provider-api/"
@@ -234,7 +235,7 @@ export default function Header() {
 								<GitHubLogoIcon className="h-4 w-4" />
 							</a>
 							<a
-								href="https://chromewebstore.google.com/detail/yours/org.yours.wallet"
+								href="https://chromewebstore.google.com/detail/yours-wallet/mlbnicldlpdimbjdcncnklfempedeipj"
 								target="_blank"
 								rel="noreferrer"
 								className="group inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20"
@@ -278,13 +279,13 @@ export default function Header() {
 									<GitbookIcon className="h-5 w-5" />
 								</a>
 								<a
-									href="https://twitter.com/yourswallet"
+									href="https://x.com/yoursxbt"
 									target="_blank"
 									rel="noreferrer"
 									className="inline-flex items-center text-white/70 transition hover:text-white"
-									aria-label="Follow Yours Wallet on Twitter"
+									aria-label="Follow Yours Wallet on X"
 								>
-									<Twitter className="h-5 w-5" />
+									<XIcon className="h-5 w-5" />
 								</a>
 								<a
 									href="https://github.com/yours-org"
@@ -320,7 +321,7 @@ export default function Header() {
 						<div className="flex flex-col gap-3">
 							{renderMobileWalletCTA()}
 							<a
-								href="https://chromewebstore.google.com/detail/yours/org.yours.wallet"
+								href="https://chromewebstore.google.com/detail/yours-wallet/mlbnicldlpdimbjdcncnklfempedeipj"
 								target="_blank"
 								rel="noreferrer"
 								className="group inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,9 +3,10 @@
 import React from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
-import { ArrowUpRight, Chrome, Network, Shield, Sparkles, Twitter } from 'lucide-react'
+import { ArrowUpRight, Chrome, Network, Shield, Sparkles } from 'lucide-react'
 import { GitHubLogoIcon, RocketIcon } from '@radix-ui/react-icons'
 import { GitbookIcon } from '@/components/icons/gitbook-icon'
+import { XIcon } from '@/components/icons/x-icon'
 
 const statHighlights = [
 	{
@@ -187,13 +188,13 @@ export default function Home() {
 						motion to get you there faster.
 					</p>
 					<a
-						href="https://twitter.com/yoursxbt"
+						href="https://x.com/yoursxbt"
 						target="_blank"
 						rel="noreferrer"
 						className="mt-8 inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-6 py-3 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20"
 					>
-						<Twitter className="h-4 w-4" />
-						<span>Follow us on Twitter</span>
+						<XIcon className="h-4 w-4" />
+						<span>Follow us on X</span>
 					</a>
 				</div>
 			</section>
@@ -208,13 +209,13 @@ export default function Home() {
 					</Link>
 					<div className="flex flex-wrap items-center gap-3 md:justify-self-end md:self-center md:justify-end md:gap-4">
 						<a
-							href="https://twitter.com/yourswallet"
+							href="https://x.com/yoursxbt"
 							target="_blank"
 							rel="noreferrer"
 							className="inline-flex items-center justify-center text-white/70 transition hover:text-white"
-							aria-label="Follow Yours Wallet on Twitter"
+							aria-label="Follow Yours Wallet on X"
 						>
-							<Twitter className="h-4 w-4" />
+							<XIcon className="h-4 w-4" />
 						</a>
 						<a
 							href="https://github.com/yours-org"

--- a/src/components/icons/x-icon.tsx
+++ b/src/components/icons/x-icon.tsx
@@ -1,0 +1,17 @@
+type XIconProps = {
+	className?: string
+}
+
+export function XIcon({ className }: XIconProps) {
+	return (
+		<svg
+			className={className}
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+		</svg>
+	)
+}


### PR DESCRIPTION
- Point brand social links to https://x.com/yoursxbt (was twitter.com, and one used the stale yourswallet handle)
- Update extension download links to the current Chrome Web Store URL
- Add XIcon component and swap lucide Twitter icon + 'Twitter' copy to X

Fixes Issue #29 